### PR TITLE
Fixes threading issue #1

### DIFF
--- a/android/src/main/kotlin/com/kasem/media_picker_builder/MediaPickerBuilderPlugin.kt
+++ b/android/src/main/kotlin/com/kasem/media_picker_builder/MediaPickerBuilderPlugin.kt
@@ -1,6 +1,7 @@
 package com.kasem.media_picker_builder
 
 import android.content.Context
+import android.os.Handler
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
@@ -44,10 +45,16 @@ class MediaPickerBuilderPlugin(private val context: Context) : MethodCallHandler
                             fileId.toLong(),
                             MediaFile.MediaType.values()[type]
                     )
-                    if (thumbnail != null)
-                        result.success(thumbnail)
-                    else
-                        result.error("NOT_FOUND", "Unable to get the thumbnail", null)
+                    val mainHandler: Handler = Handler(context.getMainLooper());
+                    val runnable: Runnable = object : Runnable {
+                        override fun run() {
+                            if (thumbnail != null)
+                                result.success(thumbnail)
+                            else
+                                result.error("NOT_FOUND", "Unable to get the thumbnail", null)
+                        }
+                    };
+                    mainHandler.post(runnable)
                 }
             }
             call.method == "getMediaFile" -> {


### PR DESCRIPTION
## Description

The call `result.success()` was happening on a background thread, which caused a crash since Flutter expects that success is called from the UiThread.

This PR fixes that issue by running the `success` call from a MainThread handler.

This solution was originally shared by @samonkoba, all thanks to them.

Fixes #1 

## Type of change

- Wrap the call to `result.success` in the `getThumbnail` method with a Handler/Runnable.

## How Has This Been Tested?

Running the example app in an Android device which had the crash issue. Then running the library integrated with a different app.
